### PR TITLE
Support Datadog credentials defined in the CloudFormation extension

### DIFF
--- a/API.md
+++ b/API.md
@@ -52,7 +52,7 @@ new DatadogDashboard(scope: Construct, id: string, props: DatadogDashboardProps)
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DatadogDashboardProps](#nomadblacky-cdk-datadog-resources-datadogdashboardprops)</code>)  *No description*
   * **dashboardDefinition** (<code>string</code>)  JSON string of the dashboard definition. 
-  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. 
+  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. __*Optional*__
 
 
 
@@ -74,11 +74,11 @@ new DatadogDowntime(scope: Construct, id: string, props: DatadogDowntimeProps)
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DatadogDowntimeProps](#nomadblacky-cdk-datadog-resources-datadogdowntimeprops)</code>)  *No description*
-  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. 
   * **scope** (<code>Array<string></code>)  The scope(s) to which the downtime applies. 
   * **active** (<code>boolean</code>)  Whether or not this downtime is currently active. __*Optional*__
   * **canceled** (<code>number</code>)  POSIX Timestamp of cancellation of this downtime (null if not canceled). __*Optional*__
   * **creatorId** (<code>number</code>)  Id of the user who created this downtime. __*Optional*__
+  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. __*Optional*__
   * **disabled** (<code>boolean</code>)  Whether or not this downtime is disabled. __*Optional*__
   * **downtimeType** (<code>number</code>)  Type of this downtime. __*Optional*__
   * **end** (<code>number</code>)  POSIX timestamp to end the downtime. __*Optional*__
@@ -111,8 +111,8 @@ new DatadogIAMUser(scope: Construct, id: string, props: DatadogIAMUserProps)
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DatadogIAMUserProps](#nomadblacky-cdk-datadog-resources-datadogiamuserprops)</code>)  *No description*
-  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. 
   * **accessRole** (<code>string</code>)  The role of the user. __*Optional*__
+  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. __*Optional*__
   * **disabled** (<code>boolean</code>)  Whether or not the user is disabled. __*Optional*__
   * **email** (<code>string</code>)  User email. __*Optional*__
   * **handle** (<code>string</code>)  User handle (a valid email). __*Optional*__
@@ -140,8 +140,8 @@ new DatadogIntegrationAWS(scope: Construct, id: string, props: DatadogIntegratio
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DatadogIntegrationAWSProps](#nomadblacky-cdk-datadog-resources-datadogintegrationawsprops)</code>)  *No description*
   * **accountId** (<code>string</code>)  The id of the account with which to integrate. 
-  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. 
   * **roleName** (<code>string</code>)  The name of the created role. 
+  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. __*Optional*__
 
 
 
@@ -163,9 +163,9 @@ new DatadogMonitor(scope: Construct, id: string, props: DatadogMonitorProps)
 * **scope** (<code>[Construct](#aws-cdk-core-construct)</code>)  *No description*
 * **id** (<code>string</code>)  *No description*
 * **props** (<code>[DatadogMonitorProps](#nomadblacky-cdk-datadog-resources-datadogmonitorprops)</code>)  *No description*
-  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. 
   * **query** (<code>string</code>)  The monitor query. 
   * **type** (<code>[MonitorType](#nomadblacky-cdk-datadog-resources-monitortype)</code>)  The type of the monitor. 
+  * **datadogCredentials** (<code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code>)  Credentials for the Datadog API. __*Optional*__
   * **message** (<code>string</code>)  A message to include with notifications for the monitor. __*Optional*__
   * **multi** (<code>boolean</code>)  Whether or not the monitor is multi alert. __*Optional*__
   * **name** (<code>string</code>)  Name of the monitor. __*Optional*__
@@ -200,7 +200,7 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **dashboardDefinition** | <code>string</code> | JSON string of the dashboard definition.
-**datadogCredentials** | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.
+**datadogCredentials**? | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.<br/>__*Optional*__
 
 
 
@@ -213,11 +213,11 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**datadogCredentials** | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.
 **scope** | <code>Array<string></code> | The scope(s) to which the downtime applies.
 **active**? | <code>boolean</code> | Whether or not this downtime is currently active.<br/>__*Optional*__
 **canceled**? | <code>number</code> | POSIX Timestamp of cancellation of this downtime (null if not canceled).<br/>__*Optional*__
 **creatorId**? | <code>number</code> | Id of the user who created this downtime.<br/>__*Optional*__
+**datadogCredentials**? | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.<br/>__*Optional*__
 **disabled**? | <code>boolean</code> | Whether or not this downtime is disabled.<br/>__*Optional*__
 **downtimeType**? | <code>number</code> | Type of this downtime.<br/>__*Optional*__
 **end**? | <code>number</code> | POSIX timestamp to end the downtime.<br/>__*Optional*__
@@ -241,8 +241,8 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**datadogCredentials** | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.
 **accessRole**? | <code>string</code> | The role of the user.<br/>__*Optional*__
+**datadogCredentials**? | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.<br/>__*Optional*__
 **disabled**? | <code>boolean</code> | Whether or not the user is disabled.<br/>__*Optional*__
 **email**? | <code>string</code> | User email.<br/>__*Optional*__
 **handle**? | <code>string</code> | User handle (a valid email).<br/>__*Optional*__
@@ -261,8 +261,8 @@ Name | Type | Description
 Name | Type | Description 
 -----|------|-------------
 **accountId** | <code>string</code> | The id of the account with which to integrate.
-**datadogCredentials** | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.
 **roleName** | <code>string</code> | The name of the created role.
+**datadogCredentials**? | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.<br/>__*Optional*__
 
 
 
@@ -275,9 +275,9 @@ Name | Type | Description
 
 Name | Type | Description 
 -----|------|-------------
-**datadogCredentials** | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.
 **query** | <code>string</code> | The monitor query.
 **type** | <code>[MonitorType](#nomadblacky-cdk-datadog-resources-monitortype)</code> | The type of the monitor.
+**datadogCredentials**? | <code>[DatadogCredentials](#nomadblacky-cdk-datadog-resources-datadogcredentials)</code> | Credentials for the Datadog API.<br/>__*Optional*__
 **message**? | <code>string</code> | A message to include with notifications for the monitor.<br/>__*Optional*__
 **multi**? | <code>boolean</code> | Whether or not the monitor is multi alert.<br/>__*Optional*__
 **name**? | <code>string</code> | Name of the monitor.<br/>__*Optional*__

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ You need to register the correct version listed in `Supported Resources`.
 ## Supported Resources
 
 | Supported? | Resource                | Datadog CF Resource Name         | Description                                              | Datadog CF Version |
-| :--------: | ----------------------- | -------------------------------- | -------------------------------------------------------- | ------------------ |
-|     ✅     | Dashboards              | `Datadog::Dashboards::Dashboard` | [Create, update, and delete Datadog dashboards.][1]      | [1.0.0][7]         |
-|     ✅     | Datadog-AWS integration | `Datadog::Integrations::AWS`     | [Manage your Datadog-Amazon Web Service integration.][2] | [1.1.0][10]        |
-|     ✅     | Monitors                | `Datadog::Monitors::Monitor`     | [Create, update, and delete Datadog monitors.][3]        | [3.0.0][6]         |
-|     ✅     | Downtimes               | `Datadog::Monitors::Downtime`    | [Enable or disable downtimes for your monitors.][4]      | [2.0.0][8]         |
-|     ✅     | Users                   | `Datadog::IAM::User`             | [Create and manage Datadog users.][5]                    | [1.2.0][9]         |
+|:----------:|-------------------------|----------------------------------|----------------------------------------------------------|--------------------|
+|     ✅      | Dashboards              | `Datadog::Dashboards::Dashboard` | [Create, update, and delete Datadog dashboards.][1]      | [1.0.0][7]         |
+|     ✅      | Datadog-AWS integration | `Datadog::Integrations::AWS`     | [Manage your Datadog-Amazon Web Service integration.][2] | [1.1.0][10]        |
+|     ✅      | Monitors                | `Datadog::Monitors::Monitor`     | [Create, update, and delete Datadog monitors.][3]        | [3.0.0][6]         |
+|     ✅      | Downtimes               | `Datadog::Monitors::Downtime`    | [Enable or disable downtimes for your monitors.][4]      | [2.0.0][8]         |
+|     ✅      | Users                   | `Datadog::IAM::User`             | [Create and manage Datadog users.][5]                    | [1.2.0][9]         |
 
 [1]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-dashboards-dashboard-handler
 [2]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-integrations-aws-handler
@@ -33,7 +33,7 @@ You need to register the correct version listed in `Supported Resources`.
 [5]: https://github.com/DataDog/datadog-cloudformation-resources/tree/master/datadog-iam-user-handler
 [6]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-monitors-monitor-handler/CHANGELOG.md#300--2021-02-16
 [7]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-dashboards-dashboard-handler/CHANGELOG.md#100--2021-02-16
-[8]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-monitors-downtime-handler/CHANGELOG.md#200--2021-02-16 
+[8]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-monitors-downtime-handler/CHANGELOG.md#200--2021-02-16
 [9]: https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-iam-user-handler/CHANGELOG.md#120--2021-02-16
 [10]:https://github.com/DataDog/datadog-cloudformation-resources/blob/master/datadog-integrations-aws-handler/CHANGELOG.md#110--2020-08-04
 
@@ -150,5 +150,28 @@ new DatadogIntegrationAWS(this, 'DataDogIntegration', {
   },
   accountId: "ACCOUNT_ID",
   roleName: "DatadogIntegrationRole",
+});
+```
+
+### Users with Datadog credentials configured in their CloudFormation extension
+
+One of the recent changes as mentioned in [issue](https://github.com/DataDog/datadog-cloudformation-resources/issues/158), the Datadog credentials have already been configured in the CloudFormation extension. Hence, you do not need to define `datadogCredentials` in your template like below:
+
+```typescript
+import { DatadogMonitor } from '@nomadblacky/cdk-datadog-resources';
+
+new DatadogMonitor(yourStack, 'TestMonitor', {
+  query: 'avg(last_1h):sum:system.cpu.system{host:host0} > 100',
+  type: MonitorType.QueryAlert,
+  name: 'Test Monitor',
+  options: {
+    thresholds: {
+      critical: 100,
+      warning: 80,
+      oK: 90,
+    },
+    notifyNoData: true,
+    evaluationDelay: 60,
+  },
 });
 ```

--- a/src/dashboards/datadog-dashboard.ts
+++ b/src/dashboards/datadog-dashboard.ts
@@ -5,7 +5,7 @@ import { DatadogCredentials } from '../common/properties';
 
 export interface DatadogDashboardProps {
   /** Credentials for the Datadog API */
-  readonly datadogCredentials: DatadogCredentials;
+  readonly datadogCredentials?: DatadogCredentials;
 
   /** JSON string of the dashboard definition */
   readonly dashboardDefinition: string;

--- a/src/integrations/datadog-integration-aws.ts
+++ b/src/integrations/datadog-integration-aws.ts
@@ -5,7 +5,7 @@ import { DatadogCredentials } from '../common/properties';
 
 export interface DatadogIntegrationAWSProps {
   /** Credentials for the Datadog API */
-  readonly datadogCredentials: DatadogCredentials;
+  readonly datadogCredentials?: DatadogCredentials;
 
   /** The id of the account with which to integrate. */
   readonly accountId: string;

--- a/src/monitors/datadog-downtime.ts
+++ b/src/monitors/datadog-downtime.ts
@@ -5,7 +5,7 @@ import { DatadogCredentials } from '../common/properties';
 
 export interface DatadogDowntimeProps {
   /** Credentials for the Datadog API */
-  readonly datadogCredentials: DatadogCredentials;
+  readonly datadogCredentials?: DatadogCredentials;
 
   /** Whether or not this downtime is currently active */
   readonly active?: boolean;

--- a/src/monitors/datadog-monitor.ts
+++ b/src/monitors/datadog-monitor.ts
@@ -6,7 +6,7 @@ import { MonitorOptions, MonitorType } from './properties';
 
 export interface DatadogMonitorProps {
   /** Credentials for the Datadog API */
-  readonly datadogCredentials: DatadogCredentials;
+  readonly datadogCredentials?: DatadogCredentials;
 
   /** The monitor query */
   readonly query: string;

--- a/src/users/datadog-user.ts
+++ b/src/users/datadog-user.ts
@@ -5,7 +5,7 @@ import { DatadogCredentials } from '../common/properties';
 
 export interface DatadogIAMUserProps {
   /** Credentials for the Datadog API */
-  readonly datadogCredentials: DatadogCredentials;
+  readonly datadogCredentials?: DatadogCredentials;
 
   /** The role of the user */
   readonly accessRole?: string;


### PR DESCRIPTION
Not sure if this is a good idea or not.

This is a quick hack to unblock myself and others who have already defined the Datadog credentials in their CloudFormation extension and users who need to define the credentials in their template because they are on older versions. 

Fixes #96 